### PR TITLE
cascade layers : important

### DIFF
--- a/plugins/postcss-cascade-layers/.tape.mjs
+++ b/plugins/postcss-cascade-layers/.tape.mjs
@@ -17,6 +17,9 @@ postcssTape(plugin)({
 	nested: {
 		message: "supports nested layer usage",
 	},
+	'nested-complex': {
+		message: "supports nested layer usage",
+	},
 	important: {
 		message: "supports important usage",
 	},
@@ -32,4 +35,12 @@ postcssTape(plugin)({
 	'invalid-rules': {
 		message: 'correctly handles invalid rules',
 	},
+	'warnings': {
+		message: 'correctly handles warnings',
+		options: {
+			onRevertLayerKeyword: 'warn',
+			onMixedLayerOrder: 'warn',
+		},
+		warnings: 2,
+	}
 });

--- a/plugins/postcss-cascade-layers/.tape.mjs
+++ b/plugins/postcss-cascade-layers/.tape.mjs
@@ -17,6 +17,9 @@ postcssTape(plugin)({
 	nested: {
 		message: "supports nested layer usage",
 	},
+	important: {
+		message: "supports important usage",
+	},
 	'anon-layer': {
 		message: "supports anonymous layer usage",
 	},

--- a/plugins/postcss-cascade-layers/README.md
+++ b/plugins/postcss-cascade-layers/README.md
@@ -58,6 +58,62 @@ instructions for:
 | [Node](INSTALL.md#node) | [PostCSS CLI](INSTALL.md#postcss-cli) | [Webpack](INSTALL.md#webpack) | [Create React App](INSTALL.md#create-react-app) | [Gulp](INSTALL.md#gulp) | [Grunt](INSTALL.md#grunt) |
 | --- | --- | --- | --- | --- | --- |
 
+## Options
+
+### onRevertLayerKeyword
+
+The `onRevertLayerKeyword` option enables warnings if `revert-layer` is used.
+Transforming `revert-layer` for older browsers is not possible in this plugin.
+
+Defaults to `warn`
+
+```js
+postcssCascadeLayers({ onRevertLayerKeyword: 'warn' }) // 'warn' | false
+```
+
+```pcss
+/* [postcss-cascade-layers]: handling "revert-layer" is unsupported by this plugin and will cause style differences between browser versions. */
+@layer {
+	.foo {
+		color: revert-layer;
+	}
+}
+```
+
+### onMixedLayerOrder
+
+The `onMixedLayerOrder` option enables warnings if layers are declared in multiple different orders in conditional rules.
+Transforming these layers correctly for older browsers is not possible in this plugin.
+
+Defaults to `warn`
+
+```js
+postcssCascadeLayers({ onMixedLayerOrder: 'warn' }) // 'warn' | false
+```
+
+```pcss
+/* [postcss-cascade-layers]: handling different layer orders in conditional rules is unsupported by this plugin and will cause style differences between browser versions. */
+@media (min-width: 10px) {
+	@layer B {
+		.foo {
+			color: red;
+		}
+	}
+}
+
+@layer A {
+	.foo {
+		color: pink;
+	}
+}
+
+@layer B {
+	.foo {
+		color: red;
+	}
+}
+```
+
 <!-- TODO : Add a reference to oddbird for doing all the heavy lifting -->
 
 [cli-url]: https://github.com/csstools/postcss-plugins/actions/workflows/test.yml?query=workflow/test

--- a/plugins/postcss-cascade-layers/docs/README.md
+++ b/plugins/postcss-cascade-layers/docs/README.md
@@ -28,6 +28,62 @@
 
 <env-support>
 
+## Options
+
+### onRevertLayerKeyword
+
+The `onRevertLayerKeyword` option enables warnings if `revert-layer` is used.
+Transforming `revert-layer` for older browsers is not possible in this plugin.
+
+Defaults to `warn`
+
+```js
+<exportName>({ onRevertLayerKeyword: 'warn' }) // 'warn' | false
+```
+
+```pcss
+/* [postcss-cascade-layers]: handling "revert-layer" is unsupported by this plugin and will cause style differences between browser versions. */
+@layer {
+	.foo {
+		color: revert-layer;
+	}
+}
+```
+
+### onMixedLayerOrder
+
+The `onMixedLayerOrder` option enables warnings if layers are declared in multiple different orders in conditional rules.
+Transforming these layers correctly for older browsers is not possible in this plugin.
+
+Defaults to `warn`
+
+```js
+<exportName>({ onMixedLayerOrder: 'warn' }) // 'warn' | false
+```
+
+```pcss
+/* [postcss-cascade-layers]: handling different layer orders in conditional rules is unsupported by this plugin and will cause style differences between browser versions. */
+@media (min-width: 10px) {
+	@layer B {
+		.foo {
+			color: red;
+		}
+	}
+}
+
+@layer A {
+	.foo {
+		color: pink;
+	}
+}
+
+@layer B {
+	.foo {
+		color: red;
+	}
+}
+```
+
 <!-- TODO : Add a reference to oddbird for doing all the heavy lifting -->
 
 <link-list>

--- a/plugins/postcss-cascade-layers/src/clean-blocks.ts
+++ b/plugins/postcss-cascade-layers/src/clean-blocks.ts
@@ -1,0 +1,30 @@
+import type { ChildNode, Container, Document } from 'postcss';
+import { CONDITIONAL_ATRULES } from './constants';
+
+export function removeEmptyDescendantBlocks(block: Container) {
+	block.walk((node) => {
+		if (node.type === 'rule' || (node.type === 'atrule' && ['layer', ...CONDITIONAL_ATRULES].includes(node.name))) {
+			if (!node.nodes || !node.nodes.length) {
+				node.remove();
+			}
+		}
+	});
+
+	if (!block.nodes || !block.nodes.length) {
+		block.remove();
+	}
+}
+
+export function removeEmptyAncestorBlocks(block: Container) {
+	let currentNode: Document | Container<ChildNode> = block;
+
+	while (currentNode) {
+		if (currentNode.nodes && currentNode.nodes.length > 0) {
+			return;
+		}
+
+		const parent = currentNode.parent;
+		currentNode.remove();
+		currentNode = parent;
+	}
+}

--- a/plugins/postcss-cascade-layers/src/constants.ts
+++ b/plugins/postcss-cascade-layers/src/constants.ts
@@ -2,3 +2,15 @@
 export const INVALID_LAYER_NAME = 'csstools-invalid-layer';
 /** @constant {string} WITH_SELECTORS_LAYER_NAME Used to replace "layer" temporarily for any layer at rules that contain selectors. This allows us to sort these differently from other layer at rules. */
 export const WITH_SELECTORS_LAYER_NAME = 'csstools-layer-with-selector-rules';
+
+export const ANONYMOUS_LAYER_SUFFIX = '6efdb677-bb05-44e5-840f-29d2175862fd';
+export const IMPLICIT_LAYER_SUFFIX = 'b147acf6-11a6-4338-a4d0-80aef4cd1a2f';
+
+export const CONDITIONAL_ATRULES = [
+	'media',
+	'supports',
+];
+
+export const ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS = [
+	'keyframes',
+];

--- a/plugins/postcss-cascade-layers/src/desugar-nested-layers.ts
+++ b/plugins/postcss-cascade-layers/src/desugar-nested-layers.ts
@@ -1,4 +1,5 @@
 import type { Container, AtRule, ChildNode } from 'postcss';
+import { removeEmptyAncestorBlocks, removeEmptyDescendantBlocks } from './clean-blocks';
 import type { Model } from './model';
 import { someAtRuleInTree } from './some-in-tree';
 
@@ -25,9 +26,8 @@ export function desugarNestedLayers(root: Container<ChildNode>, model: Model) {
 				layerRule.params = `${parent.params}.${layerRule.params}`;
 
 				parent.before(layerRule);
-				if (parent.nodes.length === 0) {
-					parent.remove();
-				}
+				removeEmptyDescendantBlocks(parent);
+				removeEmptyAncestorBlocks(parent);
 
 				return;
 			}
@@ -46,9 +46,8 @@ export function desugarNestedLayers(root: Container<ChildNode>, model: Model) {
 				parent.before(layerRuleClone);
 
 				layerRule.remove();
-				if (parent.nodes.length === 0) {
-					parent.remove();
-				}
+				removeEmptyDescendantBlocks(parent);
+				removeEmptyAncestorBlocks(parent);
 				return;
 			}
 

--- a/plugins/postcss-cascade-layers/src/get-conditional-atrule-ancestor.ts
+++ b/plugins/postcss-cascade-layers/src/get-conditional-atrule-ancestor.ts
@@ -1,0 +1,21 @@
+import type { AtRule, ChildNode, Document, Container } from 'postcss';
+import { CONDITIONAL_ATRULES } from './constants';
+
+// Returns the first ancestor of the current layerRule that is a conditional rule;
+export function getConditionalAtRuleAncestor(layerRule: AtRule): AtRule | null {
+	let parent: Container<ChildNode>|Document = layerRule.parent;
+	while (parent) {
+		if (parent.type !== 'atrule') {
+			parent = parent.parent;
+			continue;
+		}
+
+		if (CONDITIONAL_ATRULES.includes((parent as AtRule).name)) {
+			return parent as AtRule;
+		}
+
+		parent = parent.parent;
+	}
+
+	return null;
+}

--- a/plugins/postcss-cascade-layers/src/index.ts
+++ b/plugins/postcss-cascade-layers/src/index.ts
@@ -95,7 +95,7 @@ const creator: PluginCreator<undefined> = () => {
 				let specificityAdjustment = model.layerOrder.get(fullLayerName) * highestASpecificity;
 				if (rule.some((decl) => decl.type === 'decl' && decl.important)) {
 					// !important declarations have inverse priority in layers
-					specificityAdjustment = model.layerCount - model.layerOrder.get(fullLayerName) * highestASpecificity;
+					specificityAdjustment = model.layerCount - specificityAdjustment;
 				}
 
 				rule.selectors = rule.selectors.map((selector) => {

--- a/plugins/postcss-cascade-layers/src/index.ts
+++ b/plugins/postcss-cascade-layers/src/index.ts
@@ -1,6 +1,6 @@
 import selectorParser from 'postcss-selector-parser';
 import selectorSpecificity from '@csstools/selector-specificity';
-import type { Container, AtRule, PluginCreator } from 'postcss';
+import type { Container, AtRule, PluginCreator, Result } from 'postcss';
 import { Model } from './model';
 import { adjustSelectorSpecificity } from './adjust-selector-specificity';
 import { desugarAndParseLayerNames } from './desugar-and-parse-layer-names';
@@ -9,20 +9,36 @@ import { getLayerAtRuleAncestor } from './get-layer-atrule-ancestor';
 import { someAtRuleInTree } from './some-in-tree';
 import { sortRootNodes } from './sort-root-nodes';
 import { recordLayerOrder } from './record-layer-order';
-import { INVALID_LAYER_NAME } from './constants';
+import { ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS, INVALID_LAYER_NAME } from './constants';
 import { splitImportantStyles } from './split-important-styles';
+import { pluginOptions } from './options';
 
-const creator: PluginCreator<undefined> = () => {
+const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
+	const options = Object.assign({
+		onRevertLayerKeyword: 'warn',
+		onMixedLayerOrder: 'warn',
+	}, opts);
+
 	return {
 		postcssPlugin: 'postcss-cascade-layers',
-		Once(root: Container) {
-			const model = new Model();
+		Once(root: Container, { result }: { result: Result }) {
+
+			// Warnings
+			if (options.onRevertLayerKeyword) {
+				root.walkDecls((decl) => {
+					if (decl.value === 'revert-layer') {
+						decl.warn(result, 'handling "revert-layer" is unsupported by this plugin and will cause style differences between browser versions.');
+					}
+				});
+			}
 
 			splitImportantStyles(root);
 
+			const model = new Model();
+
 			desugarAndParseLayerNames(root, model);
 
-			recordLayerOrder(root, model);
+			recordLayerOrder(root, model, { result, options });
 
 			if (!model.layerCount) {
 				// Reset "invalid-layer" at rules
@@ -47,7 +63,7 @@ const creator: PluginCreator<undefined> = () => {
 			// transform unlayered styles - need highest specificity (layerCount)
 			root.walkRules((rule) => {
 				// Skip any at rules that do not contain regular declarations (@keyframes)
-				if (rule.parent && rule.parent.type === 'atrule' && (rule.parent as AtRule).name === 'keyframes') {
+				if (rule.parent && rule.parent.type === 'atrule' && ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS.includes((rule.parent as AtRule).name)) {
 					return;
 				}
 
@@ -81,7 +97,7 @@ const creator: PluginCreator<undefined> = () => {
 			//  - give selectors the specificity they need based on layerPriority state
 			root.walkRules((rule) => {
 				// Skip any at rules that do not contain regular declarations (@keyframes)
-				if (rule.parent && rule.parent.type === 'atrule' && (rule.parent as AtRule).name === 'keyframes') {
+				if (rule.parent && rule.parent.type === 'atrule' && ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS.includes((rule.parent as AtRule).name)) {
 					return;
 				}
 

--- a/plugins/postcss-cascade-layers/src/model.ts
+++ b/plugins/postcss-cascade-layers/src/model.ts
@@ -1,4 +1,5 @@
 import type { AtRule, Node } from 'postcss';
+import { ANONYMOUS_LAYER_SUFFIX, IMPLICIT_LAYER_SUFFIX } from './constants';
 
 export class Model {
 	anonymousLayerCount = 0;
@@ -23,7 +24,7 @@ export class Model {
 	}
 
 	createAnonymousLayerName(): string {
-		const name = `anon${this.anonymousLayerCount}`;
+		const name = `anonymous-${this.anonymousLayerCount}-${ANONYMOUS_LAYER_SUFFIX}`;
 		this.addLayerNameParts(name);
 		this.layerParamsParsed.set(name, [name]);
 
@@ -35,7 +36,7 @@ export class Model {
 	createImplicitLayerName(layerName: string): string {
 		const parts = this.layerNameParts.get(layerName);
 		const last = parts[parts.length - 1];
-		const name = `${last}-implicit`;
+		const name = `implicit-${last}-${IMPLICIT_LAYER_SUFFIX}`;
 
 		this.addLayerNameParts([...parts, name]);
 		this.layerParamsParsed.set(name, [name]);
@@ -88,8 +89,6 @@ export class Model {
 		// Layer names were collected inside out, so order needs to be reversed.
 		params.reverse();
 
-		// Individual layers can also be specified as `@layer foo.bar {}`.
-		// Joining and splitting by "." ensures that we handle each sub layer.
 		return params.flatMap((param) => {
 			return this.layerNameParts.get(param);
 		});

--- a/plugins/postcss-cascade-layers/src/options.ts
+++ b/plugins/postcss-cascade-layers/src/options.ts
@@ -1,0 +1,4 @@
+export type pluginOptions = {
+	onRevertLayerKeyword: 'warn'|false,
+	onMixedLayerOrder: 'warn'|false,
+}

--- a/plugins/postcss-cascade-layers/src/record-layer-order.ts
+++ b/plugins/postcss-cascade-layers/src/record-layer-order.ts
@@ -1,13 +1,30 @@
-import type { Container } from 'postcss';
+import type { Container, Result } from 'postcss';
+import { ANONYMOUS_LAYER_SUFFIX, IMPLICIT_LAYER_SUFFIX } from './constants';
+import { getConditionalAtRuleAncestor } from './get-conditional-atrule-ancestor';
 import type { Model } from './model';
+import { pluginOptions } from './options';
 
-export function recordLayerOrder(root: Container, model: Model) {
+export function recordLayerOrder(root: Container, model: Model, { result, options }: { result: Result, options: pluginOptions }) {
 	// record layer order
 	root.walkAtRules('layer', (layerRule) => {
 		const currentLayerNameParts = model.getLayerParams(layerRule);
 		const fullLayerName = currentLayerNameParts.join('.');
 		if (model.layerOrder.has(fullLayerName)) {
+			if (!layerRule.nodes || layerRule.nodes.length === 0) {
+				// Remove empty layers
+				layerRule.remove();
+			}
+
 			return;
+		}
+
+		if (
+			options.onMixedLayerOrder &&
+			getConditionalAtRuleAncestor(layerRule) &&
+			!layerRule.params.endsWith(IMPLICIT_LAYER_SUFFIX) &&
+			!layerRule.params.endsWith(ANONYMOUS_LAYER_SUFFIX)
+		) {
+			layerRule.warn(result, 'handling different layer orders in conditional rules is unsupported by this plugin and will cause style differences between browser versions.');
 		}
 
 		if (!model.layerParamsParsed.has(fullLayerName)) {
@@ -26,5 +43,10 @@ export function recordLayerOrder(root: Container, model: Model) {
 			model.layerOrder.set(name, model.layerCount);
 			model.layerCount += 1;
 		});
+
+		if (!layerRule.nodes || layerRule.nodes.length === 0) {
+			// Remove empty layers
+			layerRule.remove();
+		}
 	});
 }

--- a/plugins/postcss-cascade-layers/src/split-important-styles.ts
+++ b/plugins/postcss-cascade-layers/src/split-important-styles.ts
@@ -1,4 +1,6 @@
-import type { Container } from 'postcss';
+import type { AtRule, Container } from 'postcss';
+import { removeEmptyDescendantBlocks } from './clean-blocks';
+import { ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS } from './constants';
 
 // Declarations with !important have inverse priority in layers.
 // Splitting rules allows us to assign different specificity to rules with or without !important declarations.
@@ -9,6 +11,10 @@ export function splitImportantStyles(root: Container) {
 		}
 
 		const parent = decl.parent;
+		if (parent.parent && parent.parent.type === 'atrule' && ATRULES_WITH_NON_SELECTOR_BLOCK_LISTS.includes((parent.parent as AtRule).name)) {
+			return;
+		}
+
 		const parentClone = parent.clone();
 
 		parentClone.each((node) => {
@@ -26,5 +32,6 @@ export function splitImportantStyles(root: Container) {
 		});
 
 		parent.before(parentClone);
+		removeEmptyDescendantBlocks(parent);
 	});
 }

--- a/plugins/postcss-cascade-layers/src/split-important-styles.ts
+++ b/plugins/postcss-cascade-layers/src/split-important-styles.ts
@@ -1,0 +1,30 @@
+import type { Container } from 'postcss';
+
+// Declarations with !important have inverse priority in layers.
+// Splitting rules allows us to assign different specificity to rules with or without !important declarations.
+export function splitImportantStyles(root: Container) {
+	root.walkDecls((decl) => {
+		if (!decl.important) {
+			return;
+		}
+
+		const parent = decl.parent;
+		const parentClone = parent.clone();
+
+		parentClone.each((node) => {
+			if (node.type === 'decl' && node.important) {
+				return;
+			}
+
+			node.remove();
+		});
+
+		parent.each((node) => {
+			if (node.type === 'decl' && node.important) {
+				node.remove();
+			}
+		});
+
+		parent.before(parentClone);
+	});
+}

--- a/plugins/postcss-cascade-layers/test/important.css
+++ b/plugins/postcss-cascade-layers/test/important.css
@@ -1,0 +1,36 @@
+@layer A, B;
+
+@layer B {
+	.foo {
+		background-color: red;
+		color: red !important;
+		something-else: red !important;
+	}
+
+	.bar {
+		background-color: blue;
+		color: blue !important;
+	}
+}
+
+@layer A {
+	.foo {
+		background-color: pink;
+		color: pink !important;
+	}
+
+	.bar {
+		background-color: yellow;
+		color: green !important;
+	}
+}
+
+.foo {
+	background-color: orange;
+	color: orange !important;
+}
+
+.bar {
+	background-color: green;
+	color: purple !important;
+}

--- a/plugins/postcss-cascade-layers/test/important.expect.css
+++ b/plugins/postcss-cascade-layers/test/important.expect.css
@@ -1,0 +1,48 @@
+
+	.foo:not(#\#) {
+		color: red !important;
+		something-else: red !important;
+	}
+	.foo:not(#\#) {
+		background-color: red;
+	}
+
+	.bar:not(#\#) {
+		color: blue !important;
+	}
+
+	.bar:not(#\#) {
+		background-color: blue;
+	}
+
+.foo:not(#\##\#) {
+		color: pink !important;
+	}
+
+.foo {
+		background-color: pink;
+	}
+
+.bar:not(#\##\#) {
+		color: green !important;
+	}
+
+.bar {
+		background-color: yellow;
+	}
+
+.foo {
+	color: orange !important;
+}
+
+.foo:not(#\##\#) {
+	background-color: orange;
+}
+
+.bar {
+	color: purple !important;
+}
+
+.bar:not(#\##\#) {
+	background-color: green;
+}

--- a/plugins/postcss-cascade-layers/test/nested-complex.css
+++ b/plugins/postcss-cascade-layers/test/nested-complex.css
@@ -1,0 +1,63 @@
+@layer D, E, F, F.G, F.G.H;
+
+@layer D {
+	target {
+		order: 1;
+	}
+
+	@media screen {
+		target {
+			order: 2;
+		}
+	}
+}
+
+@media screen {
+	target {
+		layered: no;
+		order: 3;
+	}
+
+	@layer E {
+		target {
+			order: 4;
+		}
+	}
+}
+
+@media screen {
+	target {
+		layered: no;
+		order: 5;
+	}
+
+	@layer F {
+		target {
+			order: 6;
+		}
+
+		@media screen {
+			target {
+				order: 7;
+			}
+
+			@layer G {
+				target {
+					order: 8;
+				}
+
+				@media screen {
+					target {
+						order: 9;
+					}
+
+					@layer H {
+						target {
+							order: 10;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/plugins/postcss-cascade-layers/test/nested-complex.expect.css
+++ b/plugins/postcss-cascade-layers/test/nested-complex.expect.css
@@ -1,0 +1,69 @@
+
+	target {
+		order: 1;
+	}
+
+	@media screen {
+		target {
+			order: 2;
+		}
+	}
+
+@media screen {
+		target:not(#\#) {
+			order: 4;
+		}
+}
+
+@media screen {
+	target:not(#\##\##\##\##\##\##\#) {
+		layered: no;
+		order: 3;
+	}
+}
+
+@media screen {
+		target:not(#\##\##\##\##\#) {
+			order: 6;
+		}
+
+		@media screen {
+			target:not(#\##\##\##\##\#) {
+				order: 7;
+			}
+		}
+}
+
+@media screen {
+
+		@media screen {
+				target:not(#\##\##\#) {
+					order: 8;
+				}
+
+				@media screen {
+					target:not(#\##\##\#) {
+						order: 9;
+					}
+				}
+		}
+}
+
+@media screen {
+
+		@media screen {
+
+				@media screen {
+						target:not(#\##\#) {
+							order: 10;
+						}
+				}
+		}
+}
+
+@media screen {
+	target:not(#\##\##\##\##\##\##\#) {
+		layered: no;
+		order: 5;
+	}
+}

--- a/plugins/postcss-cascade-layers/test/nested.css
+++ b/plugins/postcss-cascade-layers/test/nested.css
@@ -37,6 +37,12 @@
 }
 
 @layer C {
+	@layer Z {
+		target {
+			color: yellow;
+		}
+	}
+
 	@media (prefers-color-scheme: dark) {
 		h1 {
 			color: red;
@@ -47,12 +53,6 @@
 			target {
 				color: lime;
 			}
-		}
-	}
-
-	@layer Z {
-		target {
-			color: yellow;
 		}
 	}
 }

--- a/plugins/postcss-cascade-layers/test/nested.expect.css
+++ b/plugins/postcss-cascade-layers/test/nested.expect.css
@@ -9,6 +9,9 @@
 		}
 	}
 
+@keyframes slide-left {
+	}
+
 	target {
 			color: yellow;
 		}
@@ -34,22 +37,22 @@ target:not(#\##\##\##\##\##\#) {
 		}
 
 @media (prefers-color-scheme: dark) {
-			target:not(#\##\##\##\##\##\##\#) {
-				color: lime;
-			}
-	}
-
-@media (prefers-color-scheme: dark) {
-		h1:not(#\##\##\##\##\##\##\##\#) {
+		h1:not(#\##\##\##\##\##\##\#) {
 			color: red;
 			background: black;
 		}
 	}
 
-target:not(#\##\##\##\##\##\##\##\##\#) {
+@media (prefers-color-scheme: dark) {
+			target:not(#\##\##\##\##\##\#) {
+				color: lime;
+			}
+	}
+
+target:not(#\##\##\##\##\##\##\##\#) {
 			color: yellow;
 		}
 
-target:not(#\##\##\##\##\##\##\##\##\##\#) {
+target:not(#\##\##\##\##\##\##\##\##\#) {
 		color: red;
 	}

--- a/plugins/postcss-cascade-layers/test/warnings.css
+++ b/plugins/postcss-cascade-layers/test/warnings.css
@@ -1,0 +1,27 @@
+/* [postcss-cascade-layers]: handling "revert-layer" is unsupported by this plugin and will cause style differences between browser versions. */
+@layer {
+	.foo {
+		color: revert-layer;
+	}
+}
+
+/* [postcss-cascade-layers]: handling different layer orders in conditional rules is unsupported by this plugin and will cause style differences between browser versions. */
+@media (min-width: 10px) {
+	@layer B {
+		.foo {
+			color: red;
+		}
+	}
+}
+
+@layer A {
+	.foo {
+		color: pink;
+	}
+}
+
+@layer B {
+	.foo {
+		color: red;
+	}
+}

--- a/plugins/postcss-cascade-layers/test/warnings.expect.css
+++ b/plugins/postcss-cascade-layers/test/warnings.expect.css
@@ -1,0 +1,19 @@
+/* [postcss-cascade-layers]: handling "revert-layer" is unsupported by this plugin and will cause style differences between browser versions. */
+.foo {
+		color: revert-layer;
+	}
+
+/* [postcss-cascade-layers]: handling different layer orders in conditional rules is unsupported by this plugin and will cause style differences between browser versions. */
+@media (min-width: 10px) {
+		.foo:not(#\#) {
+			color: red;
+		}
+}
+
+.foo:not(#\##\#) {
+		color: pink;
+	}
+
+.foo:not(#\#) {
+		color: red;
+	}

--- a/plugins/postcss-cascade-layers/test/wpt/layer-important.html
+++ b/plugins/postcss-cascade-layers/test/wpt/layer-important.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
-
 <head>
 	<title>CSS Cascade Layers: !important</title>
 	<meta name="assert" content="!important in CSS Cascade Layers">
-	<link rel="author" title="Antti Koivisto" href="mailto:antti@apple.com">
 	<link rel="help" href="https://www.w3.org/TR/css-cascade-5/#layering">
 </head>
 
@@ -43,13 +41,55 @@
 				},
 				// TODO : Unsure if we can implement !important correctly
 				// see : https://github.com/web-platform-tests/wpt/issues/33767
-				// {
-				// 	title: 'Same specificity, both important',
-				// 	style: `
-				// 		@layer { target { color: red !important; } }
-				// 		@layer { target { color: green !important; } }
-				// 	`,
-				// },
+				{
+					title: 'Same specificity, all important (order A)',
+					style: `
+						@layer { target { color: green !important; } }
+						@layer { target { color: red !important; } }
+						target { color: red !important; }
+					`,
+				},
+				{
+					title: 'Same specificity, all important (order B)',
+					style: `
+						@layer { target { color: green !important; } }
+						target { color: red !important; }
+						@layer { target { color: red !important; } }
+					`,
+				},
+				{
+					title: 'Same specificity, all important (order C)',
+					style: `
+						target { color: red !important; }
+						@layer { target { color: green !important; } }
+						@layer { target { color: red !important; } }
+					`,
+				},
+				{
+					title: 'Same specificity, all important (order D)',
+					style: `
+						@layer A, B;
+						@layer B { target { color: red !important; } }
+						@layer A { target { color: green !important; } }
+						target { color: red !important; }
+					`,
+				},
+				{
+					title: 'Different specificity (A), all important',
+					style: `
+						@layer { target { color: green !important; } }
+						@layer { target { color: red !important; } }
+						target.first { color: red !important; }
+					`,
+				},
+				{
+					title: 'Different specificity (B), all important',
+					style: `
+						@layer { target { color: green !important; } }
+						@layer { target.first { color: red !important; } }
+						target { color: red !important; }
+					`,
+				},
 			];
 
 			for (let testCase of testCases) {


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal,duck)

Implement `!important` handling in `@layer` :

- split rules so that `!important` declarations have their own rule
- assign inverse specificity adjustments to the rules with `!important` declarations

I did a few spot tests in Chrome Canary and transformed CSS with `!important` seems to match native `@layer` styles.