### PR TITLE
Conditional layer ordering warning name change

### DIFF
--- a/plugins/postcss-cascade-layers/.tape.mjs
+++ b/plugins/postcss-cascade-layers/.tape.mjs
@@ -39,7 +39,7 @@ postcssTape(plugin)({
 		message: 'correctly handles warnings',
 		options: {
 			onRevertLayerKeyword: 'warn',
-			onMixedLayerOrder: 'warn',
+			onConditionalRulesChangingLayerOrder: 'warn',
 		},
 		warnings: 2,
 	}

--- a/plugins/postcss-cascade-layers/README.md
+++ b/plugins/postcss-cascade-layers/README.md
@@ -80,15 +80,15 @@ postcssCascadeLayers({ onRevertLayerKeyword: 'warn' }) // 'warn' | false
 }
 ```
 
-### onMixedLayerOrder
+### onConditionalRulesChangingLayerOrder
 
-The `onMixedLayerOrder` option enables warnings if layers are declared in multiple different orders in conditional rules.
+The `onConditionalRulesChangingLayerOrder` option enables warnings if layers are declared in multiple different orders in conditional rules.
 Transforming these layers correctly for older browsers is not possible in this plugin.
 
 Defaults to `warn`
 
 ```js
-postcssCascadeLayers({ onMixedLayerOrder: 'warn' }) // 'warn' | false
+postcssCascadeLayers({ onConditionalRulesChangingLayerOrder: 'warn' }) // 'warn' | false
 ```
 
 ```pcss

--- a/plugins/postcss-cascade-layers/docs/README.md
+++ b/plugins/postcss-cascade-layers/docs/README.md
@@ -50,15 +50,15 @@ Defaults to `warn`
 }
 ```
 
-### onMixedLayerOrder
+### onConditionalRulesChangingLayerOrder
 
-The `onMixedLayerOrder` option enables warnings if layers are declared in multiple different orders in conditional rules.
+The `onConditionalRulesChangingLayerOrder` option enables warnings if layers are declared in multiple different orders in conditional rules.
 Transforming these layers correctly for older browsers is not possible in this plugin.
 
 Defaults to `warn`
 
 ```js
-<exportName>({ onMixedLayerOrder: 'warn' }) // 'warn' | false
+<exportName>({ onConditionalRulesChangingLayerOrder: 'warn' }) // 'warn' | false
 ```
 
 ```pcss

--- a/plugins/postcss-cascade-layers/src/index.ts
+++ b/plugins/postcss-cascade-layers/src/index.ts
@@ -16,7 +16,7 @@ import { pluginOptions } from './options';
 const creator: PluginCreator<pluginOptions> = (opts?: pluginOptions) => {
 	const options = Object.assign({
 		onRevertLayerKeyword: 'warn',
-		onMixedLayerOrder: 'warn',
+		onConditionalRulesChangingLayerOrder: 'warn',
 	}, opts);
 
 	return {

--- a/plugins/postcss-cascade-layers/src/options.ts
+++ b/plugins/postcss-cascade-layers/src/options.ts
@@ -1,4 +1,4 @@
 export type pluginOptions = {
 	onRevertLayerKeyword: 'warn'|false,
-	onMixedLayerOrder: 'warn'|false,
+	onConditionalRulesChangingLayerOrder: 'warn'|false,
 }

--- a/plugins/postcss-cascade-layers/src/record-layer-order.ts
+++ b/plugins/postcss-cascade-layers/src/record-layer-order.ts
@@ -19,7 +19,7 @@ export function recordLayerOrder(root: Container, model: Model, { result, option
 		}
 
 		if (
-			options.onMixedLayerOrder &&
+			options.onConditionalRulesChangingLayerOrder &&
 			getConditionalAtRuleAncestor(layerRule) &&
 			!layerRule.params.endsWith(IMPLICIT_LAYER_SUFFIX) &&
 			!layerRule.params.endsWith(ANONYMOUS_LAYER_SUFFIX)


### PR DESCRIPTION
- Changing name of warning from `onMixedLayerOrder` to `onConditionalRulesChangingLayerOrder`